### PR TITLE
fix(app): updated sdc.yaml file for kubernetes 1.8+ versions

### DIFF
--- a/statefulsets/sdc.yaml
+++ b/statefulsets/sdc.yaml
@@ -34,18 +34,6 @@ spec:
     metadata:
       labels:
         app: datacollector
-      annotations:
-        pod.beta.kubernetes.io/init-containers: '[
-          {
-            "name": "init-datacollector-data",
-            "image": "busybox",
-            "command": ["sh", "-c", "chown -R 20159 /data /opt/streamsets-datacollector/streamsets-libs"],
-            "volumeMounts": [
-              {"name": "data", "mountPath": "/data", "subPath": "data"},
-              {"name": "data", "mountPath": "/opt/streamsets-datacollector/streamsets-libs", "subPath": "stagelibs"}
-            ]
-          }
-        ]'
     spec:
       terminationGracePeriodSeconds: 10
       containers:
@@ -57,6 +45,17 @@ spec:
         readinessProbe:
           exec:
             command: ["curl", "127.0.0.1:18630/public-rest/ping"]
+        volumeMounts:
+        - name: data
+          mountPath: /data
+          subPath: data
+        - name: data
+          mountPath: /opt/streamsets-datacollector/streamsets-libs
+          subPath: stagelibs
+      initContainers:
+      - name: init-datacollector-data
+        image: busybox
+        command: ['sh', '-c', 'chown -R 20159 /data /opt/streamsets-datacollector/streamsets-libs']
         volumeMounts:
         - name: data
           mountPath: /data


### PR DESCRIPTION
Current sdc.yaml file doesnt work on newer versions of kubernetes. 
Reference: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/